### PR TITLE
Potential fix for code scanning alert no. 6: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/Backend/internal/handler/http.go
+++ b/Backend/internal/handler/http.go
@@ -225,10 +225,14 @@ func getUserID(w http.ResponseWriter, r *http.Request) string {
 		Value:    uid,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:  true,
+		Secure:   isHTTPSRequest(r),
 		SameSite: http.SameSiteLaxMode,
 	})
 	return uid
+}
+
+func isHTTPSRequest(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 }
 
 func (h *httpHandler) propRemove(w http.ResponseWriter, r *http.Request) error {

--- a/Backend/internal/handler/http.go
+++ b/Backend/internal/handler/http.go
@@ -225,6 +225,7 @@ func getUserID(w http.ResponseWriter, r *http.Request) string {
 		Value:    uid,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:  true,
 		SameSite: http.SameSiteLaxMode,
 	})
 	return uid


### PR DESCRIPTION
Potential fix for [https://github.com/AntonHritsai/self-learning-classifier/security/code-scanning/6](https://github.com/AntonHritsai/self-learning-classifier/security/code-scanning/6)

To fix this properly, set the cookie’s `Secure` attribute explicitly to `true` in the `http.Cookie` literal passed to `http.SetCookie` inside `getUserID` in `Backend/internal/handler/http.go`.

Best single change without altering existing behavior:
- Edit only the cookie construction block around lines 223–229.
- Add `Secure:  true,` alongside existing `HttpOnly` and `SameSite` fields.
- No new imports, methods, or dependencies are needed.

This preserves current logic (header lookup, existing cookie reuse, random UID generation) while ensuring newly set cookies are only transmitted via HTTPS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
